### PR TITLE
Make Infernum publicly available

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,55 +1,104 @@
-# ZSH Aliases
+# Infernum Framework - Development Guide
+
+## Project Overview
+
+Infernum is a blazingly fast local LLM inference framework written in Rust. The codebase is organized as a workspace with 10+ specialized crates.
+
+## Crate Architecture
+
+| Crate | Purpose |
+|-------|---------|
+| `infernum` | Main CLI application |
+| `infernum-core` | Shared types and traits |
+| `abaddon` | Inference engine |
+| `malphas` | Orchestration and routing |
+| `stolas` | Knowledge/RAG engine |
+| `beleth` | Agent framework |
+| `asmodeus` | Fine-tuning and LoRA |
+| `dantalion` | Observability and metrics |
+| `infernum-server` | HTTP API server (OpenAI compatible) |
+| `grimoire-loader` | Persona/prompt loading |
+
+## Development Workflow
+
+### Building
 
 ```bash
-pf               # cd to persona-framework root
-lev-clean        # Clean mammon + leviathan builds
-lev-build        # Build leviathan (-x test)
-lev-run          # Export AWS creds + bootRun
-lev-kill         # Kill all leviathan processes
-lev-restart      # Full restart: kill + clean + build + run
-lev-logs         # tail -f leviathan.out
-bael-dev         # cd bael && npm run dev
-bael-test        # cd bael && playwright headed mode
-eidolon          # Launch script (all|backend|gui|stop|restart|status)
-eidolon-start    # Start backend + GUI
-eidolon-stop     # Stop all components
-eidolon-restart  # Restart all components
-eidolon-status   # Show component status
-eidolon-backend  # Start backend only
-eidolon-gui      # Start GUI only
+cargo build --workspace
+cargo build --release --workspace
 ```
 
-# Grimoire Integration
+### Testing
 
-Prompts MUST be loaded from `/home/lilith/development/projects/grimoire/personas/` at runtime.
-PromptLoader configured to read from filesystem, NOT packaged JARs.
+```bash
+cargo test --workspace
+cargo test --workspace -- --nocapture  # with output
+```
 
-# Git Workflow
+### Linting
+
+```bash
+cargo clippy --workspace --all-features
+cargo fmt --all -- --check
+```
+
+### Running
+
+```bash
+cargo run -p infernum -- --help
+cargo run -p infernum -- serve --port 8080
+cargo run -p infernum -- chat --model "HuggingFaceTB/SmolLM2-135M"
+```
+
+## Git Workflow
 
 **CRITICAL**: Never work directly on main or development branches.
 
-For each roadmap/goal:
 1. Create feature branch: `git checkout -b feature/goal-name`
-2. Commit regularly as you make progress
-3. When complete, create PR for review
+2. Commit regularly with conventional commits
+3. Push and create PR for review
 
-Example:
 ```bash
 git checkout -b feature/streaming-chat
-# make changes
 git add -A && git commit -m "feat: streaming implementation"
-# continue work...
 git push origin feature/streaming-chat
 ```
 
-# Common Workflows
+## Conventional Commits
 
-Build + Run Leviathan:
+Use these prefixes:
+- `feat:` - New features
+- `fix:` - Bug fixes
+- `docs:` - Documentation changes
+- `refactor:` - Code refactoring
+- `test:` - Adding tests
+- `chore:` - Maintenance tasks
+- `perf:` - Performance improvements
+
+## Code Standards
+
+- Follow Rust idioms and the project's clippy configuration
+- All public items should have documentation
+- Use `thiserror` for error types
+- Use `tracing` for logging
+- Prefer async/await for I/O operations
+- Write tests for new functionality
+
+## Benchmarks
+
+Run inference benchmarks:
 ```bash
-pf && lev-clean && lev-build && lev-run
+cargo bench -p abaddon
 ```
 
-Run E2E Test:
-```bash
-pf && cd bael && npx playwright test hydra-marketing-task.e2e.spec.ts:18 --headed --project=chromium
-```
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `HF_TOKEN` | HuggingFace Hub token for gated models |
+| `INFERNUM_LOG` | Log level (trace, debug, info, warn, error) |
+| `INFERNUM_CONFIG` | Custom config file path |
+
+## Configuration
+
+Default config location: `~/.config/infernum/config.toml`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run cargo check
+        run: cargo check --workspace --all-features
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Run cargo clippy
+        run: cargo clippy --workspace --all-features -- -D warnings
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test --workspace --all-features
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build documentation
+        run: cargo doc --workspace --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: -D warnings
+
+  msrv:
+    name: MSRV (1.91)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@v2
+      - name: Check MSRV
+        run: cargo check --workspace --all-features
+
+  security:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Publish crates
+        run: |
+          # Publish in dependency order
+          cargo publish -p infernum-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p dantalion --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p grimoire-loader --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p abaddon --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p stolas --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p malphas --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p beleth --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p asmodeus --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p infernum-server --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          sleep 30
+          cargo publish -p infernum --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
+
+  build-binaries:
+    name: Build Binaries (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    needs: publish
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: infernum
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: infernum
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: infernum
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: infernum.exe
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} -p infernum
+
+      - name: Package binary (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czvf ../../../infernum-${{ github.ref_name }}-${{ matrix.target }}.tar.gz ${{ matrix.artifact }}
+
+      - name: Package binary (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          7z a ../../../infernum-${{ github.ref_name }}-${{ matrix.target }}.zip ${{ matrix.artifact }}
+
+      - name: Upload to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            infernum-${{ github.ref_name }}-${{ matrix.target }}.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to Infernum
+
+Thank you for your interest in contributing to Infernum! This document provides guidelines and instructions for contributing.
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. We're building something together.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/infernum-framework`
+3. Add upstream remote: `git remote add upstream https://github.com/Daemoniorum-LLC/infernum-framework`
+4. Create a feature branch: `git checkout -b feature/your-feature`
+
+## Development Setup
+
+### Prerequisites
+
+- Rust 1.91 or later
+- Cargo
+
+### Building
+
+```bash
+cargo build --workspace
+```
+
+### Running Tests
+
+```bash
+cargo test --workspace
+```
+
+### Linting
+
+```bash
+cargo clippy --workspace --all-features
+cargo fmt --all -- --check
+```
+
+## Making Changes
+
+### Branch Naming
+
+- `feature/` - New features
+- `fix/` - Bug fixes
+- `docs/` - Documentation improvements
+- `refactor/` - Code refactoring
+
+### Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add streaming response support
+fix: resolve memory leak in tokenizer cache
+docs: update API examples
+refactor: simplify model loading logic
+test: add integration tests for chat endpoint
+chore: update dependencies
+perf: optimize token sampling
+```
+
+### Code Style
+
+- Follow Rust idioms and best practices
+- Run `cargo fmt` before committing
+- Ensure `cargo clippy` passes without warnings
+- Add documentation for public items
+- Write tests for new functionality
+
+### Pull Request Process
+
+1. Update your fork with the latest upstream changes
+2. Ensure all tests pass: `cargo test --workspace`
+3. Ensure linting passes: `cargo clippy --workspace --all-features`
+4. Ensure formatting is correct: `cargo fmt --all -- --check`
+5. Push your branch and create a pull request
+
+### PR Guidelines
+
+- Keep PRs focused on a single change
+- Write a clear description of what and why
+- Link related issues if applicable
+- Ensure CI passes before requesting review
+
+## Architecture Overview
+
+Infernum is organized as a Rust workspace with specialized crates:
+
+| Crate | Purpose |
+|-------|---------|
+| `infernum` | CLI application |
+| `infernum-core` | Shared types and traits |
+| `abaddon` | Inference engine |
+| `malphas` | Orchestration layer |
+| `stolas` | RAG/Knowledge engine |
+| `beleth` | Agent framework |
+| `asmodeus` | Fine-tuning |
+| `dantalion` | Observability |
+| `infernum-server` | HTTP API server |
+| `grimoire-loader` | Prompt loading |
+
+## Reporting Issues
+
+When reporting bugs, please include:
+
+- Rust version (`rustc --version`)
+- OS and version
+- Steps to reproduce
+- Expected vs actual behavior
+- Relevant logs or error messages
+
+## Feature Requests
+
+Feature requests are welcome! Please:
+
+- Check existing issues first
+- Describe the use case
+- Explain why existing features don't solve it
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the same MIT OR Apache-2.0 dual license as the project.
+
+## Questions?
+
+Open an issue or start a discussion. We're happy to help!

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,190 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to the Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+Copyright 2025 Daemoniorum LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Daemoniorum LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Infernum, please report it responsibly:
+
+1. **Do not** open a public GitHub issue
+2. Email security concerns to: engineering@daemoniorum.com
+3. Include:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+   - Suggested fix (if any)
+
+## Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial Assessment**: Within 7 days
+- **Resolution Timeline**: Depends on severity
+
+## Security Considerations
+
+Infernum runs LLMs locally. Key security aspects:
+
+### Model Loading
+- Models are loaded from HuggingFace Hub or local paths
+- Verify model sources before loading untrusted models
+- GGUF and SafeTensor formats are used for model weights
+
+### API Server
+- The HTTP server binds to `0.0.0.0` by default
+- Consider firewall rules in production deployments
+- No authentication is built-in; add a reverse proxy for production
+
+### Local Execution
+- All inference runs locally on your machine
+- No data is sent to external services
+- Model weights are cached in `~/.cache/huggingface/`
+
+## Best Practices
+
+1. Run behind a reverse proxy in production
+2. Use environment variables for sensitive configuration
+3. Keep dependencies updated
+4. Monitor for security advisories in dependencies


### PR DESCRIPTION
- Add MIT and Apache-2.0 license files
- Set up GitHub Actions CI/CD workflows (test, lint, build, release)
- Add Dependabot configuration for automated dependency updates
- Add CONTRIBUTING.md with development guidelines
- Add SECURITY.md with vulnerability reporting policy
- Clean up .claude/CLAUDE.md for public consumption